### PR TITLE
fix: reduce logging when no write concern is specified

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ modowner=io.vertx
 modname=mod-mongo-persistor
 
 # Your module version
-version=3.2.2
+version=3.2.3
 
 # The test timeout
 testtimeout=300

--- a/src/main/java/org/vertx/mods/MongoPersistor.java
+++ b/src/main/java/org/vertx/mods/MongoPersistor.java
@@ -22,6 +22,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 import org.vertx.java.busmods.BusModBase;
 
 import javax.net.ssl.SSLSocketFactory;
@@ -719,8 +720,8 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
    */
   private Optional<WriteConcern> parseWriteConcern(String writeConcernField) {
     Optional<WriteConcern> writeConcern = Optional.ofNullable(WriteConcern.valueOf(writeConcernField));
-    if (!writeConcern.isPresent()) {
-      logger.warn("Write concern field is invalid : " + writeConcernField);
+    if (StringUtils.isNotEmpty(writeConcernField) && !writeConcern.isPresent()) {
+      logger.warn("Specified write concern field is invalid : " + writeConcernField);
     }
     return writeConcern;
   }


### PR DESCRIPTION
A warning will be logged only when a write concern is specified (in query, conf...) and invalid (not among the authorized mongo WriteConcern).