### PR TITLE
feat: #WB2-1421, use 2 clients in mongo persistor, one for secondary reads and one for primary reads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,18 @@
       <version>${vertxVersion}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <version>${vertxVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 </project>

--- a/src/test/java/org/vertx/mods/mongo/test/integration/org/vertx/mods/MongoPersistorTest.java
+++ b/src/test/java/org/vertx/mods/mongo/test/integration/org/vertx/mods/MongoPersistorTest.java
@@ -1,0 +1,62 @@
+package org.vertx.mods.mongo.test.integration.org.vertx.mods;
+
+import com.mongodb.ReadPreference;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.vertx.mods.MongoPersistor;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(VertxUnitRunner.class)
+public class MongoPersistorTest {
+
+  @Test
+  public void testMakeConfigurationForClientCorrectlyModifiesConfigurationForPrimary(final TestContext context) {
+    final Vertx vertx = Vertx.vertx();
+    final JsonObject config = new JsonObject()
+      .put("username", "toto")
+      .put("password", "pwd")
+      .put("authSource", "{{ dbName }}")
+      .put("authMechanism", "SCRAM-SHA-1")
+      .put("connection_string", "mongodb://toto:tata@mongo1:27017,mongo2:27017/dbname?authSource=authDb&ssl=true&maxPoolSize=110&readPreference=nearest&w=1")
+      .put("db_name", "dbname")
+      .put("use_mongo_types", true)
+      .put("use_ssl", true)
+      .put("read_preference", "nearest")
+      .put("pool_size", 110);
+    final JsonObject newConfig = MongoPersistor.makeConfigurationForClient(config, 10, ReadPreference.primary(), vertx);
+    assertEquals("Pool size should have been overridden", 10, (int)newConfig.getInteger("pool_size"));
+    assertEquals("Read preference should have been overridden", "primary", newConfig.getString("read_preference"));
+    assertEquals("Connection string should have been modifed",
+      "mongodb://toto:tata@mongo1:27017,mongo2:27017/dbname?authSource=authDb&ssl=true&maxPoolSize=110&readPreference=primary&w=1",
+      newConfig.getString("connection_string"));
+  }
+
+
+  @Test
+  public void testMakeConfigurationForClientCorrectlyModifiesConfigurationForDefault(final TestContext context) {
+    final Vertx vertx = Vertx.vertx();
+    final JsonObject config = new JsonObject()
+      .put("username", "toto")
+      .put("password", "pwd")
+      .put("authSource", "{{ dbName }}")
+      .put("authMechanism", "SCRAM-SHA-1")
+      .put("connection_string", "mongodb://toto:tata@mongo1:27017,mongo2:27017/dbname?authSource=authDb&ssl=true&maxPoolSize=110&readPreference=nearest&w=1")
+      .put("db_name", "dbname")
+      .put("use_mongo_types", true)
+      .put("use_ssl", true)
+      .put("read_preference", "nearest")
+      .put("pool_size", 110);
+    final JsonObject newConfig = MongoPersistor.makeConfigurationForClient(config, 100, null, vertx);
+    assertEquals("Pool size should have been overridden", 100, (int)newConfig.getInteger("pool_size"));
+    assertEquals("Read preference should have been overridden", "nearest", newConfig.getString("read_preference"));
+    assertEquals("Connection string should have been modifed",
+      config.getString("connection_string"),
+      newConfig.getString("connection_string"));
+
+  }
+}


### PR DESCRIPTION
# Description

With the new asynchronous mongodb driver, there is no way to sepcify a read preference for a specific query, so we have to use 2 different clients to do it. One will be the one to be used by default and the other one (with a small pool size) will be used for primary reads.